### PR TITLE
feat: only allow MetadataMap variant as metadata and check sender != …

### DIFF
--- a/contracts/MintableMappedMetadataNFT.aes
+++ b/contracts/MintableMappedMetadataNFT.aes
@@ -8,7 +8,7 @@ include "core/IAEX141NFTReceiver.aes"
 
 contract MintableMappedMetadataNFT =
 
-    datatype event 
+    datatype event
         = Transfer(address, address, int)
         | Approval(address, address, int, string)
         | ApprovalForAll(address, address, string)
@@ -33,7 +33,7 @@ contract MintableMappedMetadataNFT =
         , metadata: map(int, metadata)
         , counter: int }
 
-    stateful entrypoint init(name: string, symbol: string) = 
+    stateful entrypoint init(name: string, symbol: string) =
         require(String.length(name) >= 1, "STRING_TOO_SHORT_NAME")
         require(String.length(symbol) >= 1, "STRING_TOO_SHORT_SYMBOL")
         { owner = Contract.creator,
@@ -45,13 +45,12 @@ contract MintableMappedMetadataNFT =
           metadata = {},
           counter = 1 }
     
-    stateful entrypoint mint(owner: address, metadata: option(metadata), data: option(string)) : int =
+    stateful entrypoint mint(owner: address, metadata: option(metadata), data: option(string)) : int =  
         require_contract_owner()
         switch(metadata)
-            None =>
-                abort("NO_METADATA_PROVIDED")
+            None => abort("NO_METADATA_PROVIDED")
+            Some(MetadataIdentifier(_)) => abort("NOT_METADATA_MAP")
             Some(v) =>
-                // TODO ensure that only MetadataMap can be used as metadata
                 let token_id = state.counter
                 put(state{counter = state.counter + 1, balances[owner = 0] @ b = b + 1, owners[token_id] = owner, metadata[token_id] = v})
                 switch(invoke_nft_receiver(Contract.address, owner, token_id, data))
@@ -62,10 +61,10 @@ contract MintableMappedMetadataNFT =
     entrypoint aex141_extensions() : list(string) =
         ["mintable", "mapped_metadata"]
 
-    entrypoint meta_info() : meta_info = 
+    entrypoint meta_info() : meta_info =
         state.meta_info
 
-    entrypoint metadata(token_id: int) : option(metadata) = 
+    entrypoint metadata(token_id: int) : option(metadata) =
         Map.lookup(token_id, state.metadata)
 
     entrypoint balance(owner: address) : option(int) =
@@ -74,7 +73,8 @@ contract MintableMappedMetadataNFT =
     entrypoint owner(token_id: int) : option(address) =
         Map.lookup(token_id, state.owners)
 
-    stateful entrypoint transfer(from: address, to: address, token_id: int, data: option(string)) : unit =
+    stateful entrypoint transfer(from: address, to: address, token_id: int, data: option(string)) =
+        require(from != to, "SENDER_MUST_NOT_BE_RECEIVER")
         require_authorized(token_id)
         require_token_owner(token_id, from)
         remove_approval(token_id)
@@ -83,7 +83,7 @@ contract MintableMappedMetadataNFT =
             (true, false) => abort("SAFE_TRANSFER_FAILED")
             _ => Chain.event(Transfer(from, to, token_id))
 
-    stateful entrypoint approve(approved: address, token_id: int, enabled: bool) : unit =
+    stateful entrypoint approve(approved: address, token_id: int, enabled: bool) =
         require_authorized(token_id)
         if(enabled)
             put(state{approvals[token_id] = approved})
@@ -91,7 +91,7 @@ contract MintableMappedMetadataNFT =
             remove_approval(token_id)
         Chain.event(Approval(Call.caller, approved, token_id, Utils.bool_to_string(enabled)))
 
-    stateful entrypoint approve_all(operator: address, enabled: bool) : unit =
+    stateful entrypoint approve_all(operator: address, enabled: bool) =
         put( state { operators = { [Call.caller] = { [operator] = enabled }} } )
         Chain.event(ApprovalForAll(Call.caller, operator, Utils.bool_to_string(enabled)))
 
@@ -120,8 +120,8 @@ contract MintableMappedMetadataNFT =
                 // let old_metadata_map = state.metadata[token_id]
                 let updated_metadata_map =
                     switch(v)
-                        MetadataMap(v) => MetadataMap(v{["mutable_attributes"]=mutable_attributes})
                         MetadataIdentifier(v) => abort("ERROR_CORRUPT_METADATA")
+                        MetadataMap(v) => MetadataMap(v{["mutable_attributes"]=mutable_attributes})
                 put(state{metadata = state.metadata{[token_id]=updated_metadata_map}})
                 // Chain.event(MutableAttributesUpdated(old_metadata_map["mutable_attributes"], updated_metadata_map["mutable_attributes"]))
 


### PR DESCRIPTION
…receiver

closes #4 
closes #10 